### PR TITLE
added @compile

### DIFF
--- a/ckup.co
+++ b/ckup.co
@@ -14,6 +14,17 @@ ckup import
     template.call me = ^this
     me._
 
+  # Compiles a string template to a template function, which, when called with
+  # `context`, executes with `context` bound to `this`; otherwise `ckup` is
+  # bound to `this` to remain backwards-compatibile.
+  compile: (template) ->
+    template = Function 'ckup' \
+      'with(ckup)' + (Coco ? require \coco)compile "#template"
+    (context) ~>
+      me = ^this
+      template.call context ? me, me
+      me._
+
   # `@_` holds the code being built.
   _: ''
 

--- a/ckup.js
+++ b/ckup.js
@@ -1,12 +1,5 @@
 (function(){
-  var ckup, tag, _i, _ref, _len, __clone = function(it){
-    function fn(){ if (this.__proto__ !== it) this.__proto__ = it }
-    return fn.prototype = it, new fn;
-  }, __importAll = function(obj, src){ for (var key in src) obj[key] = src[key]; return obj }, __slice = [].slice, _fn = function(tailless, tag){
-    ckup[tag] = function(){
-      this.element(tag, arguments, tailless);
-    };
-  };
+  var ckup, tag, _i, _ref, _len, __slice = [].slice;
   ckup = typeof exports != 'undefined' && exports !== null
     ? exports
     : this.Ckup = {};
@@ -20,6 +13,18 @@
     }
     template.call(me = __clone(this));
     return me._;
+  };
+  ckup.compile = function(template){
+    var _this = this;
+    template = Function('ckup', 'with(ckup)' + (typeof Coco != 'undefined' && Coco !== null
+      ? Coco
+      : require('coco')).compile(template + ""));
+    return function(context){
+      var me;
+      me = __clone(_this);
+      template.call(context != null ? context : me, me);
+      return me._;
+    };
   };
   ckup._ = '';
   ckup.css = function(rules){
@@ -155,4 +160,17 @@
     (_fn.call(this, tag === '#' || tag === 'void' || tag === 'elements' || tag === 'area' || tag === 'base' || tag === 'br' || tag === 'col' || tag === 'command' || tag === 'embed' || tag === 'hr' || tag === 'img' || tag === 'input' || tag === 'keygen' || tag === 'link' || tag === 'meta' || tag === 'param' || tag === 'source' || tag === 'track' || tag === 'wbr', tag));
   }
   ckup.$ = ckup.quote, ckup.R = ckup.raw, ckup.T = ckup.text, ckup.E = ckup.entity, ckup.v = ckup['var'];
+  function __clone(it){
+    function fun(){} fun.prototype = it;
+    return new fun;
+  }
+  function __importAll(obj, src){
+    for (var key in src) obj[key] = src[key];
+    return obj;
+  }
+  function _fn(tailless, tag){
+    ckup[tag] = function(){
+      this.element(tag, arguments, tailless);
+    };
+  }
 }).call(this);


### PR DESCRIPTION
I added a `compile` function that compiles a Coco template string into a function to be called with a `context`:

```
    $ coco -es
    t = '''
      <~! ul
      for v, i of @
        li "#i: #v"
    '''

    f = require \ckup .compile t

    console.log f <[a b c]>

    <ul
    ><li
    >0: a</li><li
    >1: b</li><li
    >2: c</li></ul>
```

`ckup` is included with `with`, and if `context` isn't specified then it defaults to `ckup`, so these should all be equivalent:

```
    console.log ckup.render 'doctype \\html'
    # <!DOCTYPE html>
    console.log ckup.render '@doctype \\html'
    # <!DOCTYPE html>

    console.log ckup.compile('doctype \\html')!
    # <!DOCTYPE html>
    console.log ckup.compile('@doctype \\html')!
    # <!DOCTYPE html>
    console.log ckup.compile('doctype \\html') \context
    # <!DOCTYPE html>
```

The only incompatibility should be if you combine `@` and `context`:

```
    console.log ckup.compile('@doctype \\html') \context
    # TypeError: Object context has no method 'doctype'
```
