### PR TITLE
added @coco

### DIFF
--- a/ckup.co
+++ b/ckup.co
@@ -51,6 +51,69 @@ ckup import
       subrules     and code += @css subrules
     code
 
+  # Renders a function as JavaScript.
+  coco: let utilities = {
+    # Creates an object's prototypal child, ensuring `__proto__`.
+    clone: '''function(it){
+      function fun(){} fun.prototype = it;
+      return new fun;
+    }'''
+    # Sets up `.prototype` between a pair of constructors
+    # as well as `.constructor` and `.superclass` references.
+    extend: '''function(sub, sup){
+      function fun(){} fun.prototype = (sub.superclass = sup).prototype;
+      (sub.prototype = new fun).constructor = sub;
+      if (typeof sup.extended == 'function') sup.extended(sub);
+      return sub;
+    }'''
+
+    # Creates a bound method.
+    bind: '''function(obj, key){
+      return function(){ return obj[key].apply(obj, arguments) };
+    }'''
+
+    # Copies properties from right to left.
+    import: '''function(obj, src){
+      var own = {}.hasOwnProperty;
+      for (var key in src) if (own.call(src, key)) obj[key] = src[key];
+      return obj;
+    }'''
+    importAll: '''function(obj, src){
+      for (var key in src) obj[key] = src[key];
+      return obj;
+    }'''
+
+    repeatString: '''function(str, n){
+      for (var r = ''; n > 0; (n >>= 1) && (str += str)) if (n & 1) r += str;
+      return r;
+    }'''
+    repeatArray: '''function(arr, n){
+      for (var r = []; n > 0; (n >>= 1) && (arr = arr.concat(arr)))
+        if (n & 1) r.push.apply(r, arr);
+      return r;
+    }'''
+
+    of: '''function(x, arr){
+      var i = 0, l = arr.length >>> 0;
+      while (i < l) if (x === arr[i++]) return true;
+      return false;
+    }'''
+
+    # Shortcuts to speed up the lookup time for native methods.
+    split    : "''.split"
+    replace  : "''.replace"
+    toString : '{}.toString'
+    join     : '[].join'
+    slice    : '[].slice'
+  }
+    (...args, fn) ->
+      fn = "#fn"
+      preamble = ''
+      for key, val in utilities
+        if -1 is not fn.search "__#key"
+          preamble += "var __#key = #val;"
+      ";#{preamble}(#fn).apply(this, #{JSON.stringify args});"
+
   COMMA   : /\s*,\s*/
   VENDORS : <[ webkit moz ms o ]>
 

--- a/ckup.js
+++ b/ckup.js
@@ -78,6 +78,35 @@
     }
     return code;
   };
+  ckup.coco = (function(utilities){
+    return function(){
+      var args, fn, preamble, key, val, _i, _ref;
+      args = 0 < (_i = arguments.length - 1) ? __slice.call(arguments, 0, _i) : (_i = 0, []), fn = arguments[_i];
+      fn = fn + "";
+      preamble = '';
+      for (key in _ref = utilities) {
+        val = _ref[key];
+        if (-1 !== fn.search("__" + key)) {
+          preamble += "var __" + key + " = " + val + ";";
+        }
+      }
+      return ";" + preamble + "(" + fn + ").apply(this, " + JSON.stringify(args) + ");";
+    };
+  }.call(this, {
+    clone: 'function(it){\n  function fun(){} fun.prototype = it;\n  return new fun;\n}',
+    extend: 'function(sub, sup){\n  function fun(){} fun.prototype = (sub.superclass = sup).prototype;\n  (sub.prototype = new fun).constructor = sub;\n  if (typeof sup.extended == \'function\') sup.extended(sub);\n  return sub;\n}',
+    bind: 'function(obj, key){\n  return function(){ return obj[key].apply(obj, arguments) };\n}',
+    'import': 'function(obj, src){\n  var own = {}.hasOwnProperty;\n  for (var key in src) if (own.call(src, key)) obj[key] = src[key];\n  return obj;\n}',
+    importAll: 'function(obj, src){\n  for (var key in src) obj[key] = src[key];\n  return obj;\n}',
+    repeatString: 'function(str, n){\n  for (var r = \'\'; n > 0; (n >>= 1) && (str += str)) if (n & 1) r += str;\n  return r;\n}',
+    repeatArray: 'function(arr, n){\n  for (var r = []; n > 0; (n >>= 1) && (arr = arr.concat(arr)))\n    if (n & 1) r.push.apply(r, arr);\n  return r;\n}',
+    of: 'function(x, arr){\n  var i = 0, l = arr.length >>> 0;\n  while (i < l) if (x === arr[i++]) return true;\n  return false;\n}',
+    split: "''.split",
+    replace: "''.replace",
+    toString: '{}.toString',
+    join: '[].join',
+    slice: '[].slice'
+  }));
   ckup.COMMA = /\s*,\s*/;
   ckup.VENDORS = ['webkit', 'moz', 'ms', 'o'];
   ckup.quote = (function(re){


### PR DESCRIPTION
I added a `coco` function, modeled after CoffeeKup's `coffeescript` method, which serializes a function and its arguments:

```
    $ coco -es
    console.log (require \ckup .render ->
      scope =
        a: 4
        b: 2

      @script type: \text/javascript, @coco scope, ({a, b}: scope) ->
        c = ^scope
        console.log a, b, c
    )

    <script type="text/javascript"
    >;var __clone = function(it){
      function fun(){} fun.prototype = it;
      return new fun;
    };(function (scope){
        var a, b, c;
        a = scope.a, b = scope.b;
        c = __clone(scope);
        return console.log(a, b, c);
      }).apply(this, [{"a":4,"b":2}]);</script>
```

I've found this very useful for bootstrapping data into a ckup view.  The commit could be smaller (and safer) if `coco` were modified to export its `UTILITIES` somehow.
